### PR TITLE
fix ledger signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.8.0-beta.31",
+	"version": "0.8.0-beta.32",
 	"description": "Ylide Protocol SDK implementation for EVM-based blockchains",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",

--- a/src/controllers/EthereumWalletController.ts
+++ b/src/controllers/EthereumWalletController.ts
@@ -335,10 +335,7 @@ export class EthereumWalletController extends AbstractWalletController {
 	): Promise<{ message: string; r: string; s: string; v: number }> {
 		await this.ensureAccount(account);
 		const signature = await this.signer.signMessage(message);
-		// split signature
-		const r = signature.slice(0, 66);
-		const s = '0x' + signature.slice(66, 130);
-		const v = parseInt(signature.slice(130, 132), 16);
+		const { r, s, v } = ethers.utils.splitSignature(signature);
 		return { message, r, s, v };
 	}
 


### PR DESCRIPTION
Original issue: https://github.com/ethereum/go-ethereum/issues/19751#issuecomment-504900739
Ledger uses canonical v values - {0, 1}. Ethereum supports {27, 28}.
ethers.utils.splitSignature automatically handles such cases and substitute 0 to 27, 1 to 28.